### PR TITLE
v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "randolf"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "crossbeam-channel",
  "log",

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Kim Goetzke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -70,21 +70,22 @@ configuration file is created with the following default values when the applica
 [general]
 window_margin = 20
 allow_selecting_same_center_windows = true
+force_using_admin_privileges = false
 additional_workspace_count = 2
 
 [exclusion_settings]
 window_titles = [
-    "Program Manager",
-    "Windows Input Experience",
-    "Settings",
-    # And more...
+  "Program Manager",
+  "Windows Input Experience",
+  "Settings",
+  # And more...
 ]
 window_class_names = [
-    "Progman",
-    "WorkerW",
-    "Shell_TrayWnd",
-    "Shell_SecondaryTrayWnd",
-    # And more...
+  "Progman",
+  "WorkerW",
+  "Shell_TrayWnd",
+  "Shell_SecondaryTrayWnd",
+  # And more...
 ]
 ```
 
@@ -104,6 +105,15 @@ effectively means that the cursor cannot be moved away from two windows of the s
 same) until at least one of them is moved/resized. Disabling this, however, means that you will no longer be able to
 select the non-foreground window of the windows with the same center using this application. Can be configured via the
 tray icon context menu.
+
+##### force_using_admin_privileges
+
+Default: `false`
+
+Whether to force the application to run with admin privileges. This will restart the application with admin privileges
+if it is not already running with them. Without admin privileges, the application will not be able to interact at all
+with other applications that are running with admin privileges. If you (semi-)regularly use applications that require
+admin privileges, you should set this to `true` or start Randolf with admin privileges directly.
 
 ##### additional_workspace_count
 

--- a/README.md
+++ b/README.md
@@ -75,17 +75,16 @@ additional_workspace_count = 2
 
 [exclusion_settings]
 window_titles = [
-  "Program Manager",
-  "Windows Input Experience",
-  "Settings",
-  # And more...
+    "Program Manager",
+    "Windows Input Experience",
+    # And more...
 ]
 window_class_names = [
-  "Progman",
-  "WorkerW",
-  "Shell_TrayWnd",
-  "Shell_SecondaryTrayWnd",
-  # And more...
+    "Progman",
+    "WorkerW",
+    "Shell_TrayWnd",
+    "Shell_SecondaryTrayWnd",
+    # And more...
 ]
 ```
 
@@ -113,7 +112,7 @@ Default: `false`
 Whether to force the application to run with admin privileges. This will restart the application with admin privileges
 if it is not already running with them. Without admin privileges, the application will not be able to interact at all
 with other applications that are running with admin privileges. If you (semi-)regularly use applications that require
-admin privileges, you should set this to `true` or start Randolf with admin privileges directly.
+admin privileges, you should set this to `true` or, even better, simply start Randolf with admin privileges directly.
 
 ##### additional_workspace_count
 

--- a/src/api/mock_windows_api.rs
+++ b/src/api/mock_windows_api.rs
@@ -153,6 +153,11 @@ pub(crate) mod test {
   }
 
   impl WindowsApi for MockWindowsApi {
+    fn is_running_as_admin(&self) -> bool {
+      trace!("Mock windows API checks if running as admin");
+      true
+    }
+
     fn get_foreground_window(&self) -> Option<WindowHandle> {
       trace!("Mock windows API gets foreground window");
       MOCK_STATE.with(|state| state.borrow_mut().foreground_window)

--- a/src/api/real_windows_api.rs
+++ b/src/api/real_windows_api.rs
@@ -10,7 +10,7 @@ use windows::Win32::Graphics::Gdi::{
 };
 use windows::Win32::System::Com::{CLSCTX_ALL, COINIT_APARTMENTTHREADED, CoCreateInstance, CoInitializeEx};
 use windows::Win32::UI::HiDpi::{GetDpiForMonitor, PROCESS_PER_MONITOR_DPI_AWARE, SetProcessDpiAwareness};
-use windows::Win32::UI::Shell::IVirtualDesktopManager;
+use windows::Win32::UI::Shell::{IVirtualDesktopManager, IsUserAnAdmin};
 use windows::Win32::UI::WindowsAndMessaging::{
   DispatchMessageA, EnumWindows, GetClassNameW, GetCursorPos, GetDesktopWindow, GetForegroundWindow, GetWindowInfo,
   GetWindowPlacement, GetWindowTextW, IsIconic, IsWindowVisible, MSG, PM_REMOVE, PeekMessageA, PostMessageW, SW_HIDE,
@@ -36,6 +36,20 @@ impl RealWindowsApi {
 }
 
 impl WindowsApi for RealWindowsApi {
+  fn is_running_as_admin(&self) -> bool {
+    unsafe {
+      let is_admin = IsUserAnAdmin();
+      if is_admin.as_bool() {
+        trace!("This application is running with with admin privileges");
+      } else {
+        warn!(
+          "This application is NOT running with with admin privileges - it cannot interact with windows of applications that have admin privileges"
+        );
+      }
+      is_admin.as_bool()
+    }
+  }
+
   fn get_foreground_window(&self) -> Option<WindowHandle> {
     let hwnd = unsafe { GetForegroundWindow() };
 

--- a/src/api/windows_api.rs
+++ b/src/api/windows_api.rs
@@ -2,6 +2,7 @@ use crate::common::{MonitorHandle, MonitorInfo, Monitors, Point, Rect, Window, W
 use windows::Win32::UI::Shell::IVirtualDesktopManager;
 
 pub trait WindowsApi {
+  fn is_running_as_admin(&self) -> bool;
   fn get_foreground_window(&self) -> Option<WindowHandle>;
   fn set_foreground_window(&self, handle: WindowHandle);
   fn get_all_visible_windows(&self) -> Vec<Window>;

--- a/src/application_launcher.rs
+++ b/src/application_launcher.rs
@@ -33,6 +33,19 @@ impl<T: WindowsApi> ApplicationLauncher<T> {
     }
   }
 
+  pub fn get_executable_path(&self) -> String {
+    if let Ok(executable_path) = std::env::current_exe() {
+      executable_path
+        .to_str()
+        .expect("Failed to convert Randolf's executable path to string")
+        .to_string()
+    } else {
+      warn!("Failed to get Randolf's executable path");
+
+      "".to_string()
+    }
+  }
+
   pub fn get_executable_folder(&self) -> String {
     if let Ok(executable_path) = std::env::current_exe() {
       let executable_directory = executable_path
@@ -186,12 +199,21 @@ mod tests {
 
   #[test]
   fn get_executable_folder_returns_correct_path() {
-    let mock_api = MockWindowsApi;
     let config_provider = Arc::new(Mutex::new(ConfigurationProvider::default()));
-    let launcher = ApplicationLauncher::new_initialised(config_provider, mock_api);
+    let launcher = ApplicationLauncher::new_initialised(config_provider, MockWindowsApi);
 
     let folder = launcher.get_executable_folder();
 
     assert!(folder.ends_with("randolf\\target\\debug\\deps"));
+  }
+
+  #[test]
+  fn get_executable_path_returns_path_to_an_executable() {
+    let config_provider = Arc::new(Mutex::new(ConfigurationProvider::default()));
+    let launcher = ApplicationLauncher::new_initialised(config_provider, MockWindowsApi);
+
+    let path = launcher.get_executable_path();
+
+    assert!(path.ends_with(".exe"));
   }
 }

--- a/src/common/command.rs
+++ b/src/common/command.rs
@@ -12,6 +12,7 @@ pub enum Command {
   MoveWindowToWorkspace(PersistentWorkspaceId),
   OpenApplication(String, bool),
   OpenRandolfFolder,
+  RestartRandolf,
   Exit,
 }
 
@@ -27,6 +28,7 @@ impl Display for Command {
       Command::MoveWindowToWorkspace(id) => write!(f, "Move window to workspace [{id}]"),
       Command::OpenApplication(path, as_admin) => write!(f, "Open [{path}] as admin [{as_admin}]"),
       Command::OpenRandolfFolder => write!(f, "Open Randolf folder in Explorer"),
+      Command::RestartRandolf => write!(f, "Restart Randolf"),
       Command::Exit => write!(f, "Exit application"),
     }
   }

--- a/src/configuration_provider.rs
+++ b/src/configuration_provider.rs
@@ -138,7 +138,6 @@ fn default_excluded_window_titles() -> Vec<String> {
   vec![
     "Program Manager".to_string(),
     "Windows Input Experience".to_string(),
-    "Settings".to_string(),
     "".to_string(),
     "Windows Shell Experience Host".to_string(),
     "ZPToolBarParentWnd".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,9 +16,9 @@ mod workspace_manager;
 extern crate log;
 extern crate simplelog;
 
-use crate::api::RealWindowsApi;
+use crate::api::{RealWindowsApi, WindowsApi};
 use crate::application_launcher::ApplicationLauncher;
-use crate::configuration_provider::ConfigurationProvider;
+use crate::configuration_provider::{ConfigurationProvider, FORCE_USING_ADMIN_PRIVILEGES};
 use crate::hotkey_manager::HotkeyManager;
 use crate::log_manager::LogManager;
 use crate::tray_menu_manager::TrayMenuManager;
@@ -60,6 +60,18 @@ fn main() {
     .lock()
     .expect(CONFIGURATION_PROVIDER_LOCK)
     .log_current_config();
+
+  // Restart the application with admin privileges, if required
+  if !windows_api.is_running_as_admin()
+    && configuration_manager
+      .lock()
+      .expect(CONFIGURATION_PROVIDER_LOCK)
+      .get_bool(FORCE_USING_ADMIN_PRIVILEGES)
+  {
+    let executable = launcher.borrow_mut().get_executable_path();
+    launcher.borrow_mut().launch(executable, None, true);
+    return;
+  }
 
   // Create window manager and register hotkeys
   let wm = Rc::new(RefCell::new(WindowManager::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,17 @@ fn main() {
           let args = launcher.borrow_mut().get_executable_folder();
           launcher.borrow_mut().launch("explorer.exe".to_string(), Some(&args), false);
         }
+        Command::RestartRandolf => {
+          wm.borrow_mut().restore_all_managed_windows();
+          interrupt_handle.interrupt();
+          let as_admin = configuration_manager
+            .lock()
+            .expect(CONFIGURATION_PROVIDER_LOCK)
+            .get_bool(FORCE_USING_ADMIN_PRIVILEGES);
+          let args = launcher.borrow_mut().get_executable_path();
+          launcher.borrow_mut().launch(args, None, as_admin);
+          std::process::exit(0);
+        }
         Command::Exit => {
           wm.borrow_mut().restore_all_managed_windows();
           interrupt_handle.interrupt();

--- a/src/tray_menu_manager.rs
+++ b/src/tray_menu_manager.rs
@@ -1,6 +1,8 @@
 use crate::api::get_all_monitors;
 use crate::common::{Command, PersistentWorkspaceId};
-use crate::configuration_provider::{ALLOW_SELECTING_SAME_CENTER_WINDOWS, ConfigurationProvider, WINDOW_MARGIN};
+use crate::configuration_provider::{
+  ALLOW_SELECTING_SAME_CENTER_WINDOWS, ConfigurationProvider, FORCE_USING_ADMIN_PRIVILEGES, WINDOW_MARGIN,
+};
 use crate::utils::CONFIGURATION_PROVIDER_LOCK;
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -22,8 +24,9 @@ enum Event {
   DisabledItem,
   SetMargin(i32),
   ToggleSelectingSameCenterWindows,
+  ToggleForceUsingAdminPrivileges,
   LogMonitorLayout,
-  ReloadConfiguration,
+  RestartRandolf,
   OpenRandolfFolder,
 }
 
@@ -102,9 +105,6 @@ impl TrayMenuManager {
         "Explore debug settings",
         MenuBuilder::new().item("Print monitor layout to log file", Event::LogMonitorLayout),
       )
-      .item("Reload randolf.toml", Event::ReloadConfiguration)
-      .item("Open the folder containing Randolf", Event::OpenRandolfFolder)
-      .separator()
       .submenu(
         "Set window margin to...",
         MenuBuilder::new()
@@ -121,8 +121,15 @@ impl TrayMenuManager {
         config.get_bool(ALLOW_SELECTING_SAME_CENTER_WINDOWS),
         Event::ToggleSelectingSameCenterWindows,
       )
+      .checkable(
+        "Force using admin privileges",
+        config.get_bool(FORCE_USING_ADMIN_PRIVILEGES),
+        Event::ToggleForceUsingAdminPrivileges,
+      )
       .separator()
-      .item("Exit Randolf (after restoring any hidden windows)", Event::Exit)
+      .item("Open the folder containing Randolf", Event::OpenRandolfFolder)
+      .item("Restart Randolf", Event::RestartRandolf)
+      .item("Exit Randolf (restores any hidden windows)", Event::Exit)
   }
 
   // TODO: Update margins of "known" windows when the margin is changed
@@ -139,7 +146,7 @@ impl TrayMenuManager {
             .expect("Failed to open tray menu");
         }
         Event::DoubleClickTrayIcon => {
-          debug!("Double clicking tray icon is not implemented");
+          trace!("Tray icon double clicked: Not implemented");
         }
         Event::LeftClickTrayIcon => {
           tray_icon
@@ -151,15 +158,6 @@ impl TrayMenuManager {
         Event::LogMonitorLayout => {
           get_all_monitors().print_layout();
           info!("Logged monitor layout");
-        }
-        Event::ReloadConfiguration => {
-          let mut config = unlocked_config_provider(&config_provider);
-          config.reload_configuration();
-        }
-        Event::OpenRandolfFolder => {
-          command_sender
-            .send(Command::OpenRandolfFolder)
-            .expect("Failed to send open randolf folder command");
         }
         Event::SetMargin(margin) => {
           let mut config = unlocked_config_provider(&config_provider);
@@ -188,8 +186,32 @@ impl TrayMenuManager {
           config.set_bool(ALLOW_SELECTING_SAME_CENTER_WINDOWS, !is_enabled);
           debug!("Set [{:?}] to [{}]", Event::ToggleSelectingSameCenterWindows, !is_enabled);
         }
+        Event::ToggleForceUsingAdminPrivileges => {
+          let mut config = unlocked_config_provider(&config_provider);
+          let is_enabled = config.get_bool(FORCE_USING_ADMIN_PRIVILEGES);
+          if let Err(result) = tray_icon
+            .lock()
+            .expect("Failed to lock tray icon")
+            .set_menu_item_checkable(Event::ToggleForceUsingAdminPrivileges, !is_enabled)
+          {
+            error!("Failed to toggle menu item: {result}");
+          }
+          config.set_bool(FORCE_USING_ADMIN_PRIVILEGES, !is_enabled);
+          debug!("Set [{:?}] to [{}]", Event::ToggleForceUsingAdminPrivileges, !is_enabled);
+        }
+        Event::OpenRandolfFolder => {
+          command_sender
+            .send(Command::OpenRandolfFolder)
+            .expect("Failed to send open randolf folder command");
+        }
+        Event::RestartRandolf => {
+          let mut config = unlocked_config_provider(&config_provider);
+          config.reload_configuration();
+          command_sender
+            .send(Command::RestartRandolf)
+            .expect("Failed to send restart command");
+        }
         Event::Exit => {
-          info!("Attempting to exit application...");
           command_sender.send(Command::Exit).expect("Failed to send exit command");
         }
         e => {

--- a/src/tray_menu_manager.rs
+++ b/src/tray_menu_manager.rs
@@ -122,7 +122,7 @@ impl TrayMenuManager {
         Event::ToggleSelectingSameCenterWindows,
       )
       .separator()
-      .item("Exit  👋", Event::Exit)
+      .item("Exit Randolf (after restoring any hidden windows)", Event::Exit)
   }
 
   // TODO: Update margins of "known" windows when the margin is changed


### PR DESCRIPTION
# Features

- Add new configuration option called `force_using_admin_privileges` (default: `false`) that, when enabled, will cause the application to restart with admin privileges, if it was started without such privileges
- Replace the old "Reload randolf.toml" tray icon option with a "Restart Randolf" option which first reloads the configuration and then restarts the application
   - Reloading the `randolf.toml` file is necessary in case `force_using_admin_privileges` was changed
   - Restarting Randolf is required to make sure hotkey changes are applied

# Other

- Remove windows with title "Settings" from excluded windows (temporarily)
- Logs `WARN` if application does not run with admin privileges: `This application is NOT running with with admin privileges - it cannot interact with windows of applications that have admin privileges`