### PR TITLE
Fix bug where window couldn't be moved to workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "randolf"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "crossbeam-channel",
  "directories",

--- a/src/api/real_windows_api_for_dragging.rs
+++ b/src/api/real_windows_api_for_dragging.rs
@@ -114,7 +114,7 @@ impl WindowsApiForDragging {
           .send(Command::DragWindows(true))
           .expect("Failed to send drag window command");
         let key_press_delay_in_ms = KEY_PRESS_DELAY_IN_MS.get().expect("Key press delay not initialised");
-        debug!("Installed mouse hook after {}ms delay", key_press_delay_in_ms);
+        trace!("Installed mouse hook after {}ms delay", key_press_delay_in_ms);
       } else {
         trace!("Win key no longer pressed when timer expired");
       }

--- a/src/common/monitors.rs
+++ b/src/common/monitors.rs
@@ -49,13 +49,13 @@ impl Monitors {
   }
 
   pub fn log_detected_monitors(&self) {
-    debug!("┌| Detected monitors:");
+    trace!("┌| Detected monitors:");
     let last_monitor = self.monitors.len().saturating_sub(1);
     for (i, monitor) in self.monitors.iter().enumerate() {
       if i != last_monitor {
-        debug!("├> {}", monitor);
+        trace!("├> {}", monitor);
       } else {
-        debug!("└> {}", monitor);
+        trace!("└> {}", monitor);
       }
     }
   }

--- a/src/common/workspace.rs
+++ b/src/common/workspace.rs
@@ -195,9 +195,10 @@ impl Workspace {
       );
     } else {
       warn!(
-        "{} already exists in workspace [{}], ignoring request",
+        "{} already exists in workspace [{}], only hiding it on current workspace",
         window.handle, self.id
       );
+      windows_api.do_hide_window(window.handle);
     }
   }
 

--- a/src/common/workspace.rs
+++ b/src/common/workspace.rs
@@ -195,7 +195,7 @@ impl Workspace {
       );
     } else {
       warn!(
-        "{} already exists in workspace [{}], only hiding it on current workspace",
+        "{} already exists in workspace [{}], only hiding it now",
         window.handle, self.id
       );
       windows_api.do_hide_window(window.handle);
@@ -443,7 +443,7 @@ mod tests {
   }
 
   #[test]
-  fn store_and_hide_window_does_not_add_duplicate_window() {
+  fn store_and_hide_window_does_not_add_duplicate_window_but_hides_it() {
     let mut workspace = Workspace::new_test(PersistentWorkspaceId::new_test(1), &Monitor::mock_1());
     let window = Window::new_test(1, Rect::new(0, 0, 100, 100));
     MockWindowsApi::add_or_update_window(window.handle, window.title.clone(), window.rect.into(), false, false, true);
@@ -453,6 +453,7 @@ mod tests {
     workspace.store_and_hide_window(window.clone(), 1.into(), &mock_api);
 
     assert_eq!(workspace.get_windows().len(), 1);
+    assert!(mock_api.is_window_hidden(&window.handle));
   }
 
   #[test]


### PR DESCRIPTION
## Bugs

- Fix bug where a window that is stored in an inactive workspace but is subsequently unhidden by Windows or another application and shown in an active workspace can no longer moved to the inactive workspace
   - This bug was caused by the request being ignored because the workspace already stored the window
   - For reference: There's likely still a bug in the scenario where a window that is stored in an inactive workspace but is subsequently unhidden by Windows or another application and shown in an active workspace _and_ the user switches back and forth between the inactive and active workspace - in this scenario, the window may be shown in both workspaces but I cannot reproduce this scenario on this machine

## Other

- Lower a few logs from `DEBUG` to `TRACE