### PR TITLE
Stop resolving to parent window when trying to drag or resize window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "randolf"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "crossbeam-channel",
  "directories",


### PR DESCRIPTION
## Feature

- Stop resolving to parent `HWND` when using shortcut to drag/resize a window but simply use the detected window handle instead
  - The previous way to resolve to the parent window (if there was one) would stop you from dragging/resizing child windows such as the Settings window of RustRover which turned out to be rather annoying as it is often those that you want to change