### PR TITLE
Fix mouse hook screen lock clash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "randolf"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "crossbeam-channel",
  "directories",


### PR DESCRIPTION
## Features

- Fix bug where the mouse resize/drag feature would remain active (or even start) after locking the screen with `Win` + `L`
  - This is unintended but more importantly...
  - It causes feature to still be active when  signing back into Windows
  - This can be very confusing for the user