### PR TITLE
Improve multi-monitor layout interactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "randolf"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "crossbeam-channel",
  "directories",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 # Meet Randolf
 
-Randolf is a small window management utility for Windows 11 that allows you to:
+Randolf is a small window management utility for Windows 11. Using the default layout configuration (i.e. `spatial`
+layout), it allows you to:
 
 - `Win` + `\` - near-maximise the foreground window (maximise minus margin).
 - `Win` + `Shift` + `Left`/`Up`/`Right`/`Down` or `h`/`j`/`k`/`l` - near-snap (snap minus margin) the foreground window
@@ -148,7 +149,8 @@ mode = "spatial"
 
 ### Spatial layout
 
-The spatial layout is the default, non-imposing layout that you can see in most of the GIFs above.
+The spatial layout is the default, non-imposing layout that you can see in most of the GIFs above. It allows you to
+move windows freely.
 
 | Key                                   | Default value | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 |---------------------------------------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -168,8 +170,7 @@ active member.
 - `Win` + `Up`/`Down` - retains normal spatial window and monitor navigation (effectively no-op unless you have a
   multi-monitor setup with a monitor below/above).
 - `Win` + `Shift` + `Left`/`Right` - reorders the focused member without leaving the strip.
-- `Win` + `Shift` + `Up`/`Down` - moves the focused member to an adjacent monitor, when one exists, near-maximises it
-  there, and releases it from the strip.
+- `Win` + `Shift` + `Up`/`Down` - moves the focused member to an adjacent monitor, when one exists.
 - `Win` + `Ctrl` + `Left`/`Right` - narrow or widen the foreground scrolling layout window through its width presets.
 - Hold `Win` + `Right click` - select a window anywhere and resize it but, on release, snaps to the nearest width preset
   once on release.
@@ -181,10 +182,10 @@ be reconciled.
 Width presets (i.e. the size of a window in the scrolling layout) follow windows between scrolling layout monitors and
 are recalculated for the target monitor. Moving into spatial layout releases the window.
 
-| Key                             | Default value | Description                                                            |
-|---------------------------------|---------------|------------------------------------------------------------------------|
-| `animation_duration_in_ms`      | `120`         | Duration of horizontal scrolling transitions, in milliseconds.         |
-| `reconciliation_interval_in_ms` | `250`         | Interval between external window reconciliation runs, in milliseconds. |
+| Key                             | Default value | Description                                                                   |
+|---------------------------------|---------------|-------------------------------------------------------------------------------|
+| `animation_duration_in_ms`      | `120`         | Duration of horizontal scrolling transitions shifting focus, in milliseconds. |
+| `reconciliation_interval_in_ms` | `250`         | Interval between external window reconciliation runs, in milliseconds.        |
 
 ### Exclusion settings
 
@@ -250,11 +251,14 @@ Randolf was created as a simpler alternative that:
 - Does not require a paid commercial licence
 - Runs as a standalone application
 - Only includes a handful of essential window management features
-- Provides hotkeys to facilitate a clean desktop without forcing automatic tiling
+- Provides hotkeys to facilitate a clean desktop without forcing automatic tiling*
 - Served as a fun, little personal learning project
 
 If you are looking for a feature-rich window manager, I strongly recommend checking
 out [Komorebi](https://github.com/LGUG2Z/komorebi/).
+
+\* This is only true if you use the default `spatial` layout. The `scrolling` layout which was implemented much later
+does enforce window height.
 
 ## How to develop
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ active member.
 - `Win` + `Left`/`Right` - selects an adjacent member and animates the outgoing and incoming windows across the strip.
 - `Win` + `Up`/`Down` - retains normal spatial window and monitor navigation (effectively no-op unless you have a
   multi-monitor setup with a monitor below/above).
-- `Win` + `Shift` + `Left`/`Right` - reorders the focused member. Vertical keyboard moves are ignored.
+- `Win` + `Shift` + `Left`/`Right` - reorders the focused member without leaving the strip.
+- `Win` + `Shift` + `Up`/`Down` - moves the focused member to an adjacent monitor, when one exists, near-maximises it
+  there, and releases it from the strip.
 - `Win` + `Ctrl` + `Left`/`Right` - narrow or widen the foreground scrolling layout window through its width presets.
 - Hold `Win` + `Right click` - select a window anywhere and resize it but, on release, snaps to the nearest width preset
   once on release.

--- a/src/api/mock_windows_api.rs
+++ b/src/api/mock_windows_api.rs
@@ -23,6 +23,7 @@ pub(crate) mod test {
     position_batches: Vec<Vec<(WindowHandle, Rect)>>,
     deferred_positioning_failures: HashSet<WindowHandle>,
     deferred_positioning_attempts: HashMap<WindowHandle, usize>,
+    window_position_minimum_dimensions: HashMap<WindowHandle, (i32, i32)>,
   }
 
   struct WindowState {
@@ -155,6 +156,16 @@ pub(crate) mod test {
       trace!("Mock windows API sets cursor position to {position}");
       MOCK_STATE.with(|state| {
         state.borrow_mut().cursor_position = position;
+      });
+    }
+
+    /// Configures the minimum dimensions enforced during window positioning.
+    pub fn set_window_position_minimum_dimensions(handle: WindowHandle, width: i32, height: i32) {
+      MOCK_STATE.with(|state| {
+        state
+          .borrow_mut()
+          .window_position_minimum_dimensions
+          .insert(handle, (width, height));
       });
     }
 
@@ -314,10 +325,15 @@ pub(crate) mod test {
       })
     }
 
-    fn set_window_position(&self, handle: WindowHandle, rect: Rect) {
+    fn set_window_position(&self, handle: WindowHandle, mut rect: Rect) {
       trace!("Mock windows API sets window position for {handle} to {rect}");
       MOCK_STATE.with(|state| {
-        if let Some(window_state) = state.borrow_mut().windows.get_mut(&handle) {
+        let mut state = state.borrow_mut();
+        if let Some((minimum_width, minimum_height)) = state.window_position_minimum_dimensions.get(&handle).copied() {
+          rect.right = rect.left + rect.width().max(minimum_width);
+          rect.bottom = rect.top + rect.height().max(minimum_height);
+        }
+        if let Some(window_state) = state.windows.get_mut(&handle) {
           window_state.window_placement = WindowPlacement::new_from_rect(rect);
           window_state.window.rect = rect;
         }
@@ -473,10 +489,21 @@ pub(crate) mod test {
       MOCK_STATE.with(|state| state.borrow().windows.get(&handle).map(|w| w.window_placement.clone()))
     }
 
-    fn set_window_placement_and_force_repaint(&self, handle: WindowHandle, placement: WindowPlacement) {
+    fn get_minimum_window_dimensions(&self, handle: WindowHandle) -> Option<(i32, i32)> {
+      trace!("Mock windows API gets minimum window dimensions for {handle}");
+      MOCK_STATE.with(|state| state.borrow().window_position_minimum_dimensions.get(&handle).copied())
+    }
+
+    fn set_window_placement_and_force_repaint(&self, handle: WindowHandle, mut placement: WindowPlacement) {
       trace!("Mock windows API sets window placement for {handle} - {placement:?}");
       MOCK_STATE.with(|state| {
-        let Some(window_state) = state.borrow_mut().windows.get_mut(&handle).map(|window_state| {
+        let mut state = state.borrow_mut();
+        if let Some((minimum_width, minimum_height)) = state.window_position_minimum_dimensions.get(&handle).copied() {
+          let rect = &mut placement.normal_position;
+          rect.right = rect.left + rect.width().max(minimum_width);
+          rect.bottom = rect.top + rect.height().max(minimum_height);
+        }
+        let Some(window_state) = state.windows.get_mut(&handle).map(|window_state| {
           window_state.window.rect = placement.normal_position;
           window_state.window.center = Point::from_center_of_rect(&placement.normal_position);
           window_state.window_placement = placement;

--- a/src/api/real_windows_api.rs
+++ b/src/api/real_windows_api.rs
@@ -15,10 +15,10 @@ use windows::Win32::UI::Shell::{IVirtualDesktopManager, IsUserAnAdmin};
 use windows::Win32::UI::WindowsAndMessaging::{
   BeginDeferWindowPos, DeferWindowPos, DispatchMessageA, EndDeferWindowPos, EnumWindows, GetClassNameW, GetCursorPos,
   GetDesktopWindow, GetForegroundWindow, GetWindowInfo, GetWindowPlacement, GetWindowRect, GetWindowTextW,
-  GetWindowThreadProcessId, HWND_TOP, IsIconic, IsWindowVisible, MSG, PM_REMOVE, PeekMessageA, PostMessageW, SW_HIDE,
-  SW_MAXIMIZE, SW_MINIMIZE, SW_RESTORE, SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOZORDER, SWP_SHOWWINDOW, SendMessageW,
-  SetCursorPos, SetForegroundWindow, SetWindowPlacement, SetWindowPos, ShowWindow, TranslateMessage, WINDOWINFO,
-  WINDOWPLACEMENT, WM_CLOSE, WM_PAINT,
+  GetWindowThreadProcessId, HWND_TOP, IsIconic, IsWindowVisible, MINMAXINFO, MSG, PM_REMOVE, PeekMessageA, PostMessageW,
+  SW_HIDE, SW_MAXIMIZE, SW_MINIMIZE, SW_RESTORE, SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOZORDER, SWP_SHOWWINDOW,
+  SendMessageW, SetCursorPos, SetForegroundWindow, SetWindowPlacement, SetWindowPos, ShowWindow, TranslateMessage,
+  WINDOWINFO, WINDOWPLACEMENT, WM_CLOSE, WM_GETMINMAXINFO, WM_PAINT,
 };
 use windows::core::BOOL;
 use windows::core::HRESULT;
@@ -461,6 +461,25 @@ impl WindowsApi for RealWindowsApi {
     }
 
     Some(WindowPlacement::from(placement))
+  }
+
+  fn get_minimum_window_dimensions(&self, handle: WindowHandle) -> Option<(i32, i32)> {
+    let mut info = MINMAXINFO::default();
+    unsafe {
+      SendMessageW(
+        handle.as_hwnd(),
+        WM_GETMINMAXINFO,
+        None,
+        Some(LPARAM(&mut info as *mut MINMAXINFO as isize)),
+      );
+    }
+    let width = info.ptMinTrackSize.x.max(0);
+    let height = info.ptMinTrackSize.y.max(0);
+    if width == 0 && height == 0 {
+      None
+    } else {
+      Some((width, height))
+    }
   }
 
   fn set_window_placement_and_force_repaint(&self, handle: WindowHandle, placement: WindowPlacement) {

--- a/src/api/windows_api.rs
+++ b/src/api/windows_api.rs
@@ -37,6 +37,8 @@ pub trait WindowsApi {
   fn do_unhide_window(&self, handle: WindowHandle);
   fn do_close_window(&self, handle: WindowHandle);
   fn get_window_placement(&self, handle: WindowHandle) -> Option<WindowPlacement>;
+  /// Returns application-reported minimum tracking width and height.
+  fn get_minimum_window_dimensions(&self, handle: WindowHandle) -> Option<(i32, i32)>;
   fn set_window_placement_and_force_repaint(&self, handle: WindowHandle, placement: WindowPlacement);
   fn do_restore_window_placement(&self, handle: WindowHandle, previous_placement: WindowPlacement);
   fn get_cursor_position(&self) -> Point;

--- a/src/common/placement.rs
+++ b/src/common/placement.rs
@@ -118,11 +118,13 @@ impl Placement {
   /// Applies a size and corrects hidden Windows borders when margins are disabled.
   pub(crate) fn resize<T: WindowsApi>(&self, api: &T, handle: WindowHandle, sizing: Sizing, margin: i32) {
     api.set_window_placement_and_force_repaint(handle, WindowPlacement::new_from_sizing(sizing.clone()));
+    self.correct_hidden_borders(api, handle, &sizing, margin);
+  }
 
-    // If margins are disabled, attempt a Desktop Window Manager-aware correction
+  fn correct_hidden_borders<T: WindowsApi>(&self, api: &T, handle: WindowHandle, sizing: &Sizing, margin: i32) {
     if margin == 0
       && let Some(rect) = api.get_extended_frame_bounds(handle).or_else(|| api.get_window_rect(handle))
-      && let Some(compensating_rect) = calculate_compensating_rect_if_required(&rect, &sizing)
+      && let Some(compensating_rect) = calculate_compensating_rect_if_required(&rect, sizing)
     {
       api.set_window_position(handle, compensating_rect);
     }

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -6,4 +6,3 @@ pub const PROJECT_DIR_ORGANISATION_NAME: &str = "kimgoetzke";
 pub const PROJECT_DIR_APPLICATION_NAME: &str = "randolf";
 pub const MINIMUM_WINDOW_MARGIN: i32 = 5;
 pub const MINIMUM_WINDOW_DIMENSION: i32 = 250;
-pub const MINIMUM_WINDOW_DIMENSION_DIVISOR: i32 = 8;

--- a/src/window_manager/spatial_layout.rs
+++ b/src/window_manager/spatial_layout.rs
@@ -1,7 +1,7 @@
 use super::navigation;
 use crate::api::WindowsApi;
-use crate::common::{Direction, Monitor, MonitorInfo, Placement, Point, Sizing, WindowHandle, WindowPlacement};
-use crate::utils::{MINIMUM_WINDOW_DIMENSION, MINIMUM_WINDOW_DIMENSION_DIVISOR};
+use crate::common::{Direction, Monitor, MonitorInfo, Placement, Point, Rect, Sizing, WindowHandle, WindowPlacement};
+use crate::utils::MINIMUM_WINDOW_DIMENSION;
 
 /// A layout that does not manage any windows. Handles geometry-based window movement, resizing, and follow-up focus.
 #[derive(Debug, Default)]
@@ -58,6 +58,8 @@ impl SpatialLayout {
     };
     let work_area = monitor_info.work_area;
     let current_sizing = Sizing::from(current_placement.normal_position);
+
+    // Calculate desired size
     let new_sizing = if placement.is_near_maximised(api, &current_placement, &handle, &monitor_info, margin) {
       Sizing::three_quarter_near_maximised(work_area, direction, margin)
     } else if placement.is_three_quarter_near_maximised(api, &handle, &monitor_info, direction, margin) {
@@ -71,23 +73,35 @@ impl SpatialLayout {
       "Expected size of {}: ({},{})x({},{})",
       handle, new_sizing.x, new_sizing.y, new_sizing.width, new_sizing.height
     );
-    let min_width = MINIMUM_WINDOW_DIMENSION.max((work_area.right - work_area.left) / MINIMUM_WINDOW_DIMENSION_DIVISOR);
-    let min_height = MINIMUM_WINDOW_DIMENSION.max((work_area.bottom - work_area.top) / MINIMUM_WINDOW_DIMENSION_DIVISOR);
+
+    // Calculate minimum permitted dimensions
+    let (mut min_width, mut min_height) = calculate_minimum_resize_dimensions(work_area, margin);
+    if let Some((application_min_width, application_min_height)) = api.get_minimum_window_dimensions(handle) {
+      min_width = min_width.max(application_min_width);
+      min_height = min_height.max(application_min_height);
+    }
     if new_sizing.width < min_width || new_sizing.height < min_height {
-      let is_below_constant = min_width <= MINIMUM_WINDOW_DIMENSION || min_height <= MINIMUM_WINDOW_DIMENSION;
       debug!(
-        "Not resizing {} because resulting size ({}x{}) is below minimum ({}x{}) (hit {} threshold)",
-        handle,
-        new_sizing.width,
-        new_sizing.height,
-        min_width,
-        min_height,
-        if is_below_constant { "constant" } else { "dynamic" }
+        "Not resizing {} because resulting size ({}x{}) is below minimum ({}x{})",
+        handle, new_sizing.width, new_sizing.height, min_width, min_height
       );
       return;
     }
+
+    // Action resizing and revert if it does not succeed
     let cursor_target = Point::from_center_of_sizing(&new_sizing);
-    placement.resize(api, handle, new_sizing, margin);
+    placement.resize(api, handle, new_sizing.clone(), margin);
+    let has_resize_succeeded = api
+      .get_window_placement(handle)
+      .is_some_and(|actual| placement.is_of_expected_size(api, handle, &actual, &new_sizing, margin));
+    if !has_resize_succeeded {
+      warn!(
+        "Restoring {} because Windows did not apply the complete requested resize",
+        handle
+      );
+      api.do_restore_window_placement(handle, current_placement);
+      return;
+    }
     api.set_cursor_position(&cursor_target);
   }
 
@@ -97,6 +111,19 @@ impl SpatialLayout {
       navigation::find_and_select_closest_window(api, window);
     }
   }
+}
+
+fn calculate_minimum_resize_dimensions(work_area: Rect, margin: i32) -> (i32, i32) {
+  let quarter_width = Sizing::left_half_of_screen(work_area, margin)
+    .halved(Direction::Left, margin)
+    .width;
+  let quarter_height = Sizing::top_half_of_screen(work_area, margin)
+    .halved(Direction::Up, margin)
+    .height;
+  (
+    MINIMUM_WINDOW_DIMENSION.max(quarter_width),
+    MINIMUM_WINDOW_DIMENSION.max(quarter_height),
+  )
 }
 
 fn window_and_monitor_info<T: WindowsApi>(api: &T) -> Option<(WindowHandle, WindowPlacement, MonitorInfo)> {

--- a/src/window_manager/spatial_layout.rs
+++ b/src/window_manager/spatial_layout.rs
@@ -1,6 +1,6 @@
 use super::navigation;
 use crate::api::WindowsApi;
-use crate::common::{Direction, MonitorInfo, Placement, Point, Sizing, WindowHandle, WindowPlacement};
+use crate::common::{Direction, Monitor, MonitorInfo, Placement, Point, Sizing, WindowHandle, WindowPlacement};
 use crate::utils::{MINIMUM_WINDOW_DIMENSION, MINIMUM_WINDOW_DIMENSION_DIVISOR};
 
 /// A layout that does not manage any windows. Handles geometry-based window movement, resizing, and follow-up focus.
@@ -25,9 +25,7 @@ impl SpatialLayout {
       let current_monitor = api.get_monitor_handle_for_window_handle(handle);
       if let Some(target_monitor) = monitors.get(direction, current_monitor) {
         debug!("Moving window to [{}]", target_monitor);
-        api.set_window_position(handle, target_monitor.work_area);
-        placement.near_maximise(api, handle, MonitorInfo::from(target_monitor), margin);
-        api.set_cursor_position(&target_monitor.center);
+        self.move_window_to_monitor(api, placement, handle, target_monitor, margin);
       } else {
         debug!("No monitor found in [{:?}] direction, did not move window", direction);
       }
@@ -37,6 +35,20 @@ impl SpatialLayout {
     let cursor_target = Point::from_center_of_sizing(&sizing);
     placement.resize(api, handle, sizing, margin);
     api.set_cursor_position(&cursor_target);
+  }
+
+  /// Moves and near-maximises a window on a target monitor.
+  pub(super) fn move_window_to_monitor<T: WindowsApi>(
+    &self,
+    api: &T,
+    placement: &Placement,
+    handle: WindowHandle,
+    target: &Monitor,
+    margin: i32,
+  ) {
+    api.set_window_position(handle, target.work_area);
+    placement.near_maximise(api, handle, MonitorInfo::from(target), margin);
+    api.set_cursor_position(&target.center);
   }
 
   /// Steps the foreground window through the spatial sizes for a direction.

--- a/src/window_manager/tests/scrolling_layout_tests.rs
+++ b/src/window_manager/tests/scrolling_layout_tests.rs
@@ -315,7 +315,7 @@ fn scrolling_focus_animates_batched_intermediate_positions() {
 }
 
 #[test]
-fn scrolling_layout_disables_vertical_move_and_resize() {
+fn scrolling_layout_vertical_move_no_ops_without_adjacent_monitor_and_disables_spatial_resize() {
   let (mut manager, _directory) = scrolling_manager();
   manager.reconcile_layouts();
   let initial = manager.windows_api.get_window_placement(1.into()).unwrap();

--- a/src/window_manager/tests/spatial_layout_tests.rs
+++ b/src/window_manager/tests/spatial_layout_tests.rs
@@ -1,6 +1,6 @@
 use crate::api::{MockWindowsApi, WindowsApi};
 use crate::common::{Direction, MonitorHandle, Point, Rect, Sizing, WindowHandle, WindowPlacement};
-use crate::utils::{MINIMUM_WINDOW_DIMENSION, MINIMUM_WINDOW_DIMENSION_DIVISOR};
+use crate::utils::MINIMUM_WINDOW_DIMENSION;
 use crate::window_manager::WindowManager;
 
 #[test]
@@ -141,17 +141,12 @@ fn resize_spatial_window_three_quarter_left_halves_normally_in_down_direction() 
 }
 
 #[test]
-fn resize_spatial_window_does_nothing_when_dynamic_minimum_exceeds_constant_and_result_is_below_it() {
-  // Use a screen wide enough that W/DIVISOR > MINIMUM_WINDOW_DIMENSION, so the dynamic minimum
-  // takes over. Work area width = MINIMUM * DIVISOR * 2, giving dynamic_min = MINIMUM * 2.
-  // The window is sized so its halved width falls between the constant and the dynamic minimum.
+fn resize_spatial_window_does_nothing_when_quarter_floor_exceeds_pixel_floor_and_result_is_below_it() {
   let monitor_handle = MonitorHandle::from(1);
   let window_handle = WindowHandle::new(1);
-  let work_area_width = MINIMUM_WINDOW_DIMENSION * MINIMUM_WINDOW_DIMENSION_DIVISOR * 2;
-  // dynamic_min = work_area_width / DIVISOR = MINIMUM_WINDOW_DIMENSION * 2
+  let work_area_width = 4000;
   let sizing = Sizing::new(20, 20, MINIMUM_WINDOW_DIMENSION * 3, 600);
-  // halved width = (MINIMUM * 3) / 2 - half_margin (with default margin 20)
-  // = 375 - 10 = 365, which is > MINIMUM (250) but < dynamic_min (500) → blocked
+  // Halved width is 365px: above the 250px floor but below this monitor's margin-aware quarter step.
   MockWindowsApi::add_or_update_window(window_handle, "Test Window".to_string(), sizing.clone(), false, false, true);
   MockWindowsApi::add_monitor(monitor_handle, Rect::new(0, 0, work_area_width, 1020), true);
   MockWindowsApi::place_window(window_handle, monitor_handle);
@@ -176,13 +171,10 @@ fn resize_spatial_window_does_nothing_when_dynamic_minimum_exceeds_constant_and_
 }
 
 #[test]
-fn resize_spatial_window_allows_resize_when_constant_is_larger_than_quarter_screen() {
-  // Dynamic min = max(MINIMUM_WINDOW_DIMENSION, work_area/DIVISOR). On a 1000px-wide screen,
-  // work_area/DIVISOR = 980/8 = 122 < MINIMUM_WINDOW_DIMENSION (250), so the constant wins.
-  // A window whose halved width (365px) exceeds the constant should be allowed to resize.
+fn resize_spatial_window_allows_resize_above_pixel_floor_when_quarter_step_is_smaller() {
   let monitor_handle = MonitorHandle::from(1);
   let window_handle = WindowHandle::new(1);
-  // Monitor 1000px wide -> work_area 1000px wide -> quarter = 250 < MINIMUM_WINDOW_DIMENSION (350)
+  // Margin-aware quarter width is 225px, so the 250px floor applies; the 365px target remains valid.
   let sizing = Sizing::new(20, 20, 750, 560);
   MockWindowsApi::add_or_update_window(window_handle, "Test Window".to_string(), sizing.clone(), false, false, true);
   MockWindowsApi::add_monitor(monitor_handle, Rect::new(0, 0, 1000, 620), true);
@@ -208,11 +200,9 @@ fn resize_spatial_window_allows_resize_when_constant_is_larger_than_quarter_scre
 
 #[test]
 fn resize_spatial_window_halves_left_half_of_screen_in_left_direction() {
-  // With DIVISOR=8, dynamic_min = max(MINIMUM, W/8). On a 2000px screen, dynamic_min = max(250, 250) = 250.
-  // Halving left_half produces ~475px > 250 -> resize succeeds.
   let monitor_handle = MonitorHandle::from(1);
   let window_handle = WindowHandle::new(1);
-  let work_area = Rect::new(0, 0, MINIMUM_WINDOW_DIMENSION * MINIMUM_WINDOW_DIMENSION_DIVISOR, 1000);
+  let work_area = Rect::new(0, 0, 2000, 1000);
   let left_half = Sizing::left_half_of_screen(work_area, 20);
   MockWindowsApi::add_or_update_window(
     window_handle,
@@ -222,11 +212,7 @@ fn resize_spatial_window_halves_left_half_of_screen_in_left_direction() {
     false,
     true,
   );
-  MockWindowsApi::add_monitor(
-    monitor_handle,
-    Rect::new(0, 0, MINIMUM_WINDOW_DIMENSION * MINIMUM_WINDOW_DIMENSION_DIVISOR, 1020),
-    true,
-  );
+  MockWindowsApi::add_monitor(monitor_handle, Rect::new(0, 0, 2000, 1020), true);
   MockWindowsApi::place_window(window_handle, monitor_handle);
   let initial_cursor = Point::default();
   MockWindowsApi::set_cursor_position(initial_cursor);
@@ -250,12 +236,40 @@ fn resize_spatial_window_halves_left_half_of_screen_in_left_direction() {
 }
 
 #[test]
-fn resize_spatial_window_halves_right_half_of_screen_in_right_direction() {
-  // Mirror of the Left case: with DIVISOR=8, dynamic_min = max(250, 250) = 250.
-  // Halving right_half produces ~475px > 250 -> resize succeeds.
+fn resize_spatial_window_restores_bottom_half_when_application_rejects_quarter_height() {
   let monitor_handle = MonitorHandle::from(1);
   let window_handle = WindowHandle::new(1);
-  let work_area = Rect::new(0, 0, MINIMUM_WINDOW_DIMENSION * MINIMUM_WINDOW_DIMENSION_DIVISOR, 1000);
+  let work_area = Rect::new(0, 0, 2000, 2000);
+  let bottom_half = Sizing::bottom_half_of_screen(work_area, 20);
+  MockWindowsApi::add_or_update_window(
+    window_handle,
+    "Test Window".to_string(),
+    bottom_half.clone(),
+    false,
+    false,
+    true,
+  );
+  MockWindowsApi::add_monitor(monitor_handle, Rect::new(0, 0, 2000, 2020), true);
+  MockWindowsApi::place_window(window_handle, monitor_handle);
+  MockWindowsApi::set_window_position_minimum_dimensions(window_handle, 0, 600);
+  let initial_cursor = Point::new(40, 50);
+  MockWindowsApi::set_cursor_position(initial_cursor);
+  let mut manager = WindowManager::default(MockWindowsApi);
+
+  manager.resize_spatial_window(Direction::Down);
+
+  assert_eq!(
+    manager.windows_api.get_window_placement(window_handle),
+    Some(WindowPlacement::new_from_sizing(bottom_half))
+  );
+  assert_eq!(manager.windows_api.get_cursor_position(), initial_cursor);
+}
+
+#[test]
+fn resize_spatial_window_restores_right_half_when_application_rejects_quarter_width() {
+  let monitor_handle = MonitorHandle::from(1);
+  let window_handle = WindowHandle::new(1);
+  let work_area = Rect::new(0, 0, 2000, 1000);
   let right_half = Sizing::right_half_of_screen(work_area, 20);
   MockWindowsApi::add_or_update_window(
     window_handle,
@@ -265,11 +279,37 @@ fn resize_spatial_window_halves_right_half_of_screen_in_right_direction() {
     false,
     true,
   );
-  MockWindowsApi::add_monitor(
-    monitor_handle,
-    Rect::new(0, 0, MINIMUM_WINDOW_DIMENSION * MINIMUM_WINDOW_DIMENSION_DIVISOR, 1020),
+  MockWindowsApi::add_monitor(monitor_handle, Rect::new(0, 0, 2000, 1020), true);
+  MockWindowsApi::place_window(window_handle, monitor_handle);
+  MockWindowsApi::set_window_position_minimum_dimensions(window_handle, 600, 0);
+  let initial_cursor = Point::new(40, 50);
+  MockWindowsApi::set_cursor_position(initial_cursor);
+  let mut manager = WindowManager::default(MockWindowsApi);
+
+  manager.resize_spatial_window(Direction::Right);
+
+  assert_eq!(
+    manager.windows_api.get_window_placement(window_handle),
+    Some(WindowPlacement::new_from_sizing(right_half))
+  );
+  assert_eq!(manager.windows_api.get_cursor_position(), initial_cursor);
+}
+
+#[test]
+fn resize_spatial_window_halves_right_half_of_screen_in_right_direction() {
+  let monitor_handle = MonitorHandle::from(1);
+  let window_handle = WindowHandle::new(1);
+  let work_area = Rect::new(0, 0, 2000, 1000);
+  let right_half = Sizing::right_half_of_screen(work_area, 20);
+  MockWindowsApi::add_or_update_window(
+    window_handle,
+    "Test Window".to_string(),
+    right_half.clone(),
+    false,
+    false,
     true,
   );
+  MockWindowsApi::add_monitor(monitor_handle, Rect::new(0, 0, 2000, 1020), true);
   MockWindowsApi::place_window(window_handle, monitor_handle);
   let initial_cursor = Point::default();
   MockWindowsApi::set_cursor_position(initial_cursor);
@@ -290,6 +330,56 @@ fn resize_spatial_window_halves_right_half_of_screen_in_right_direction() {
     initial_cursor,
     "Cursor should have moved"
   );
+}
+
+#[test]
+fn resize_spatial_window_keeps_half_size_when_quarter_is_below_pixel_floor() {
+  let monitor_handle = MonitorHandle::from(1);
+  let window_handle = WindowHandle::new(1);
+  let work_area = Rect::new(0, 0, 800, 1000);
+  let right_half = Sizing::right_half_of_screen(work_area, 20);
+  MockWindowsApi::add_or_update_window(
+    window_handle,
+    "Test Window".to_string(),
+    right_half.clone(),
+    false,
+    false,
+    true,
+  );
+  MockWindowsApi::add_monitor(monitor_handle, Rect::new(0, 0, 800, 1020), true);
+  MockWindowsApi::place_window(window_handle, monitor_handle);
+  let initial_cursor = Point::new(40, 50);
+  MockWindowsApi::set_cursor_position(initial_cursor);
+  let mut manager = WindowManager::default(MockWindowsApi);
+
+  manager.resize_spatial_window(Direction::Right);
+
+  assert_eq!(
+    manager.windows_api.get_window_placement(window_handle),
+    Some(WindowPlacement::new_from_sizing(right_half))
+  );
+  assert_eq!(manager.windows_api.get_cursor_position(), initial_cursor);
+}
+
+#[test]
+fn resize_spatial_window_does_nothing_when_halving_would_fall_below_quarter_step() {
+  let monitor_handle = MonitorHandle::from(1);
+  let window_handle = WindowHandle::new(1);
+  let sizing = Sizing::new(20, 20, 800, 960);
+  MockWindowsApi::add_or_update_window(window_handle, "Test Window".to_string(), sizing.clone(), false, false, true);
+  MockWindowsApi::add_monitor(monitor_handle, Rect::new(0, 0, 2000, 1020), true);
+  MockWindowsApi::place_window(window_handle, monitor_handle);
+  let initial_cursor = Point::new(40, 50);
+  MockWindowsApi::set_cursor_position(initial_cursor);
+  let mut manager = WindowManager::default(MockWindowsApi);
+
+  manager.resize_spatial_window(Direction::Left);
+
+  assert_eq!(
+    manager.windows_api.get_window_placement(window_handle),
+    Some(WindowPlacement::new_from_sizing(sizing))
+  );
+  assert_eq!(manager.windows_api.get_cursor_position(), initial_cursor);
 }
 
 #[test]
@@ -346,8 +436,7 @@ fn resize_spatial_window_does_nothing_when_no_foreground_window() {
 
 #[test]
 fn resize_spatial_window_does_nothing_when_result_height_falls_below_constant_minimum() {
-  // Down halved height = 300/2 - half_margin = 140 < MINIMUM_WINDOW_DIMENSION (250) -> blocked.
-  // On this screen, dynamic_min_height = max(250, 980/8) = 250, so the constant is the threshold.
+  // Down halved height is 140px, below the 250px floor.
   let monitor_handle = MonitorHandle::from(1);
   let window_handle = WindowHandle::new(1);
   let sizing = Sizing::new(20, 20, 500, 300);
@@ -375,13 +464,11 @@ fn resize_spatial_window_does_nothing_when_result_height_falls_below_constant_mi
 }
 
 #[test]
-fn resize_spatial_window_does_nothing_when_dynamic_minimum_height_blocks_resize() {
-  // Work area height = MINIMUM * DIVISOR * 2 -> dynamic_min_height = MINIMUM * 2.
-  // Window height = MINIMUM * 3; halved = MINIMUM * 3 / 2 - half_margin, which is
-  // > MINIMUM (constant) but < dynamic_min (MINIMUM * 2) -> blocked.
+fn resize_spatial_window_does_nothing_when_quarter_height_floor_blocks_resize() {
+  // Halved height is 365px: above the 250px floor but below this monitor's margin-aware quarter step.
   let monitor_handle = MonitorHandle::from(1);
   let window_handle = WindowHandle::new(1);
-  let work_area_height = MINIMUM_WINDOW_DIMENSION * MINIMUM_WINDOW_DIMENSION_DIVISOR * 2;
+  let work_area_height = 4000;
   let sizing = Sizing::new(20, 20, 500, MINIMUM_WINDOW_DIMENSION * 3);
   MockWindowsApi::add_or_update_window(window_handle, "Test Window".to_string(), sizing.clone(), false, false, true);
   MockWindowsApi::add_monitor(monitor_handle, Rect::new(0, 0, 2000, work_area_height + 20), true);
@@ -590,7 +677,7 @@ fn resize_spatial_window_steps_near_maximised_down_to_three_quarter_in_direction
 fn resize_spatial_window_halves_non_near_maximised_window_in_direction() {
   let monitor_handle = MonitorHandle::from(1);
   let window_handle = WindowHandle::new(1);
-  // Width must be > 2 * dynamic_min (2 * W/4 = 1000) so that halved width (590) > dynamic_min (500)
+  // Halved width is 590px, above this monitor's 475px margin-aware quarter step.
   let sizing = Sizing::new(20, 20, 1200, 960);
   MockWindowsApi::add_or_update_window(window_handle, "Test Window".to_string(), sizing.clone(), false, false, true);
   MockWindowsApi::add_monitor(monitor_handle, Rect::new(0, 0, 2000, 1020), true);

--- a/src/window_manager/tests/window_manager_tests.rs
+++ b/src/window_manager/tests/window_manager_tests.rs
@@ -10,10 +10,19 @@ use crate::workspace_manager::WorkspaceManager;
 use std::sync::{Arc, Mutex};
 
 fn vertical_mixed_layout_manager(direction: Direction, target_layout: Layout) -> (WindowManager<MockWindowsApi>, Monitor) {
+  vertical_mixed_layout_manager_with_widths(direction, target_layout, 1_000, 1_000)
+}
+
+fn vertical_mixed_layout_manager_with_widths(
+  direction: Direction,
+  target_layout: Layout,
+  source_width: i32,
+  target_width: i32,
+) -> (WindowManager<MockWindowsApi>, Monitor) {
   MockWindowsApi::reset();
   let (source_area, target_area) = match direction {
-    Direction::Up => (Rect::new(0, 1_000, 1_000, 2_000), Rect::new(0, 0, 1_000, 1_000)),
-    Direction::Down => (Rect::new(0, 0, 1_000, 1_000), Rect::new(0, 1_000, 1_000, 2_000)),
+    Direction::Up => (Rect::new(0, 1_000, source_width, 2_000), Rect::new(0, 0, target_width, 1_000)),
+    Direction::Down => (Rect::new(0, 0, source_width, 1_000), Rect::new(0, 1_000, target_width, 2_000)),
     Direction::Left | Direction::Right => panic!("vertical fixture requires Up or Down"),
   };
   let mut source_monitor = Monitor::new_test(1, source_area);
@@ -194,16 +203,163 @@ fn move_window_with_scrolling_source_reflows_without_stealing_focus_after_spatia
 }
 
 #[test]
-fn move_window_when_scrolling_vertically_move_does_not_enter_another_scrolling_monitor() {
-  let (mut manager, _target_monitor) = vertical_mixed_layout_manager(Direction::Down, Layout::Scrolling);
+fn move_window_with_scrolling_window_can_move_down_to_scrolling_monitor() {
+  let (mut manager, target_monitor) = vertical_mixed_layout_manager(Direction::Down, Layout::Scrolling);
   let handle = WindowHandle::new(1);
   let source_workspace = manager.scrolling.get_workspace_containing(handle).unwrap();
-  let before = manager.windows_api.get_window_placement(handle).unwrap();
+  let source_width = manager
+    .windows_api
+    .get_window_placement(handle)
+    .unwrap()
+    .normal_position
+    .width();
 
   manager.move_window(Direction::Down);
 
-  assert_eq!(manager.windows_api.get_window_placement(handle).unwrap(), before);
-  assert_eq!(manager.scrolling.get_workspace_containing(handle), Some(source_workspace));
+  let target_workspace = manager.scrolling.get_workspace_containing(handle).unwrap();
+  let target_placement = manager.windows_api.get_window_placement(handle).unwrap();
+  assert_ne!(target_workspace, source_workspace);
+  assert_eq!(manager.scrolling.get_members(target_workspace), vec![handle]);
+  assert_eq!(target_placement.normal_position.width(), source_width);
+  assert_eq!(target_placement.normal_position.top, target_monitor.work_area.top + 20);
+  assert_eq!(target_placement.normal_position.bottom, target_monitor.work_area.bottom - 20);
+  assert_eq!(manager.windows_api.get_foreground_window(), Some(handle));
+  assert_eq!(manager.windows_api.get_cursor_position(), target_monitor.center);
+}
+
+#[test]
+fn move_window_between_scrolling_monitors_retains_width_preset() {
+  let (mut manager, target_monitor) =
+    vertical_mixed_layout_manager_with_widths(Direction::Down, Layout::Scrolling, 1_000, 2_000);
+  let handle = WindowHandle::new(1);
+  assert_eq!(
+    manager
+      .windows_api
+      .get_window_placement(handle)
+      .unwrap()
+      .normal_position
+      .width(),
+    320
+  );
+
+  manager.move_window(Direction::Down);
+
+  let target_width = target_monitor.work_area.width() - 40;
+  assert_eq!(
+    manager
+      .windows_api
+      .get_window_placement(handle)
+      .unwrap()
+      .normal_position
+      .width(),
+    target_width / 3
+  );
+}
+
+#[test]
+fn move_window_between_scrolling_monitors_reflows_source_without_stealing_focus() {
+  let (mut manager, target_monitor) = vertical_mixed_layout_manager(Direction::Down, Layout::Scrolling);
+  let moved_handle = WindowHandle::new(1);
+  let source_workspace = manager.scrolling.get_workspace_containing(moved_handle).unwrap();
+  let source_monitor = manager.workspace_manager.monitor_for_workspace(source_workspace).unwrap();
+  let remaining_handle = WindowHandle::new(2);
+  MockWindowsApi::add_or_update_window(
+    remaining_handle,
+    "Remaining".to_string(),
+    Sizing::new(600, 100, 300, 700),
+    false,
+    false,
+    false,
+  );
+  MockWindowsApi::place_window(remaining_handle, source_monitor.handle);
+  manager.reconcile_layouts();
+  MockWindowsApi::set_foreground_window(moved_handle);
+  MockWindowsApi::set_cursor_position(source_monitor.center);
+
+  manager.move_window(Direction::Down);
+
+  let remaining_placement = manager.windows_api.get_window_placement(remaining_handle).unwrap();
+  assert_eq!(
+    Point::from_center_of_rect(&remaining_placement.normal_position),
+    source_monitor.center
+  );
+  assert_eq!(
+    manager.scrolling.get_workspace_containing(remaining_handle),
+    Some(source_workspace)
+  );
+  assert_eq!(manager.windows_api.get_foreground_window(), Some(moved_handle));
+  assert_eq!(manager.windows_api.get_cursor_position(), target_monitor.center);
+}
+
+#[test]
+fn move_window_to_scrolling_monitor_appends_to_target_strip() {
+  let (mut manager, target_monitor) = vertical_mixed_layout_manager(Direction::Down, Layout::Scrolling);
+  let moved_handle = WindowHandle::new(1);
+  for (handle, left) in [(WindowHandle::new(2), 100), (WindowHandle::new(3), 600)] {
+    MockWindowsApi::add_or_update_window(
+      handle,
+      format!("Target {}", handle.hwnd),
+      Sizing::new(left, target_monitor.work_area.top + 100, 300, 700),
+      false,
+      false,
+      false,
+    );
+    MockWindowsApi::place_window(handle, target_monitor.handle);
+  }
+  manager.reconcile_layouts();
+  MockWindowsApi::set_foreground_window(moved_handle);
+
+  manager.move_window(Direction::Down);
+
+  let target_workspace = manager.scrolling.get_workspace_containing(moved_handle).unwrap();
+  assert_eq!(
+    manager.scrolling.get_members(target_workspace),
+    vec![2.into(), 3.into(), moved_handle]
+  );
+}
+
+#[test]
+fn move_window_between_scrolling_monitors_does_not_restore_former_strip_position() {
+  let (mut manager, _target_monitor) = vertical_mixed_layout_manager(Direction::Down, Layout::Scrolling);
+  let stationary_handle = WindowHandle::new(1);
+  let source_workspace = manager.scrolling.get_workspace_containing(stationary_handle).unwrap();
+  let source_monitor = manager.workspace_manager.monitor_for_workspace(source_workspace).unwrap();
+  let moved_handle = WindowHandle::new(2);
+  MockWindowsApi::add_or_update_window(
+    moved_handle,
+    "Moved".to_string(),
+    Sizing::new(100, 100, 300, 700),
+    false,
+    false,
+    true,
+  );
+  MockWindowsApi::place_window(moved_handle, source_monitor.handle);
+  manager.reconcile_layouts();
+  assert_eq!(
+    manager.scrolling.get_members(source_workspace),
+    vec![moved_handle, stationary_handle]
+  );
+
+  manager.move_window(Direction::Down);
+  manager.move_window(Direction::Up);
+
+  assert_eq!(
+    manager.scrolling.get_members(source_workspace),
+    vec![stationary_handle, moved_handle] // Window is appended instead of restored
+  );
+}
+
+#[test]
+fn move_window_with_scrolling_window_can_move_up_to_scrolling_monitor() {
+  let (mut manager, target_monitor) = vertical_mixed_layout_manager(Direction::Up, Layout::Scrolling);
+  let handle = WindowHandle::new(1);
+
+  manager.move_window(Direction::Up);
+
+  let target_workspace = manager.scrolling.get_workspace_containing(handle).unwrap();
+  assert_eq!(target_workspace.monitor_id, target_monitor.id);
+  assert_eq!(manager.windows_api.get_foreground_window(), Some(handle));
+  assert_eq!(manager.windows_api.get_cursor_position(), target_monitor.center);
 }
 
 #[test]
@@ -512,16 +668,16 @@ fn move_window_to_workspace_when_moving_from_spatial_to_scrolling_inserts_strip_
     .lock()
     .unwrap()
     .set_monitor_layout("DISPLAY1", Layout::Scrolling);
-  let secondary = WindowHandle::new(2);
+  let secondary_handle = WindowHandle::new(2);
   MockWindowsApi::add_or_update_window(
-    secondary,
+    secondary_handle,
     "Secondary".to_string(),
     Sizing::new(-700, 50, 400, 300),
     false,
     false,
     true,
   );
-  MockWindowsApi::place_window(secondary, 2.into());
+  MockWindowsApi::place_window(secondary_handle, 2.into());
   let primary_workspace = *crate::workspace_manager::tests::primary_active_ws_id();
   let mut manager = WindowManager {
     configuration_provider,
@@ -538,7 +694,7 @@ fn move_window_to_workspace_when_moving_from_spatial_to_scrolling_inserts_strip_
   manager.move_window_to_workspace(primary_workspace.into());
 
   assert_eq!(
-    manager.scrolling.get_workspace_containing(secondary),
+    manager.scrolling.get_workspace_containing(secondary_handle),
     Some(primary_workspace.into())
   );
 }

--- a/src/window_manager/tests/window_manager_tests.rs
+++ b/src/window_manager/tests/window_manager_tests.rs
@@ -1,11 +1,68 @@
 use crate::api::{MockWindowsApi, WindowsApi};
-use crate::common::{Direction, MonitorHandle, PersistentWorkspaceId, Point, Rect, Sizing, WindowHandle, WindowPlacement};
+use crate::common::{
+  Direction, Monitor, MonitorHandle, PersistentWorkspaceId, Point, Rect, Sizing, WindowHandle, WindowPlacement, Workspace,
+};
 use crate::configuration_provider::{ConfigurationProvider, Layout};
 use crate::utils::create_temp_directory;
 use crate::window_manager::WindowManager;
 use crate::window_manager::tests::test_support::scrolling_manager;
 use crate::workspace_manager::WorkspaceManager;
 use std::sync::{Arc, Mutex};
+
+fn vertical_mixed_layout_manager(direction: Direction, target_layout: Layout) -> (WindowManager<MockWindowsApi>, Monitor) {
+  MockWindowsApi::reset();
+  let (source_area, target_area) = match direction {
+    Direction::Up => (Rect::new(0, 1_000, 1_000, 2_000), Rect::new(0, 0, 1_000, 1_000)),
+    Direction::Down => (Rect::new(0, 0, 1_000, 1_000), Rect::new(0, 1_000, 1_000, 2_000)),
+    Direction::Left | Direction::Right => panic!("vertical fixture requires Up or Down"),
+  };
+  let mut source_monitor = Monitor::new_test(1, source_area);
+  source_monitor.is_primary = true;
+  let target_monitor = Monitor::new_test(2, target_area);
+  for monitor in [&source_monitor, &target_monitor] {
+    MockWindowsApi::add_monitor_with_full_details(
+      monitor.id,
+      monitor.handle,
+      monitor.monitor_area,
+      monitor.work_area,
+      monitor.is_primary,
+    );
+  }
+  let source_workspace_id = PersistentWorkspaceId::new(source_monitor.id, 1, true);
+  let target_workspace_id = PersistentWorkspaceId::new(target_monitor.id, 1, false);
+  let source_workspace = Workspace::new_active(source_workspace_id, &source_monitor, 20);
+  let target_workspace = Workspace::new_active(target_workspace_id, &target_monitor, 20);
+  let workspace_manager = WorkspaceManager::from_workspaces(&[&source_workspace, &target_workspace], 20);
+  let handle = WindowHandle::new(1);
+  MockWindowsApi::add_or_update_window(
+    handle,
+    "Source".to_string(),
+    Sizing::new(source_area.left + 100, source_area.top + 100, 400, 700),
+    false,
+    false,
+    true,
+  );
+  MockWindowsApi::place_window(handle, source_monitor.handle);
+  MockWindowsApi::set_cursor_position(source_monitor.center);
+  let configuration_provider = Arc::new(Mutex::new(ConfigurationProvider::default()));
+  configuration_provider.lock().unwrap().set_default_layout(Layout::Scrolling);
+  configuration_provider
+    .lock()
+    .unwrap()
+    .set_monitor_layout(&target_monitor.id_to_string(), target_layout);
+  let mut manager = WindowManager {
+    configuration_provider,
+    placement: Default::default(),
+    allow_moving_cursor_after_close_or_minimise: true,
+    scrolling: Default::default(),
+    spatial: Default::default(),
+    workspace_manager,
+    virtual_desktop_manager: None,
+    windows_api: MockWindowsApi,
+  };
+  manager.reconcile_layouts();
+  (manager, target_monitor)
+}
 
 #[test]
 fn resize_scrolling_window_command_no_ops_for_spatial_layout() {
@@ -27,7 +84,7 @@ fn resize_scrolling_window_command_no_ops_for_spatial_layout() {
 }
 
 #[test]
-fn mixed_layout_routes_move_by_foreground_monitor() {
+fn move_window_with_mixed_layout_routes_move_by_foreground_monitor() {
   MockWindowsApi::reset();
   let directory = create_temp_directory();
   let workspace_manager = WorkspaceManager::new_test(true, directory.path().join("workspaces.toml"));
@@ -64,8 +121,149 @@ fn mixed_layout_routes_move_by_foreground_monitor() {
   );
   MockWindowsApi::set_foreground_window(1.into());
   let primary_before = manager.windows_api.get_window_placement(1.into()).unwrap();
+
   manager.move_window(Direction::Up);
   assert_eq!(manager.windows_api.get_window_placement(1.into()).unwrap(), primary_before);
+}
+
+#[test]
+fn move_window_with_scrolling_window_can_move_down_to_spatial_monitor() {
+  let (mut manager, target_monitor) = vertical_mixed_layout_manager(Direction::Down, Layout::Spatial);
+  let handle = WindowHandle::new(1);
+
+  manager.move_window(Direction::Down);
+
+  assert!(manager.scrolling.get_workspace_containing(handle).is_none());
+  assert_eq!(
+    manager.windows_api.get_window_placement(handle).unwrap(),
+    WindowPlacement::new_from_sizing(Sizing::near_maximised(target_monitor.work_area, 20))
+  );
+  assert_eq!(manager.windows_api.get_foreground_window(), Some(handle));
+  assert_eq!(manager.windows_api.get_cursor_position(), target_monitor.center);
+}
+
+#[test]
+fn move_window_with_scrolling_window_can_move_up_to_spatial_monitor() {
+  let (mut manager, target_monitor) = vertical_mixed_layout_manager(Direction::Up, Layout::Spatial);
+  let handle = WindowHandle::new(1);
+
+  manager.move_window(Direction::Up);
+
+  assert!(manager.scrolling.get_workspace_containing(handle).is_none());
+  assert_eq!(
+    manager.windows_api.get_window_placement(handle).unwrap(),
+    WindowPlacement::new_from_sizing(Sizing::near_maximised(target_monitor.work_area, 20))
+  );
+  assert_eq!(manager.windows_api.get_foreground_window(), Some(handle));
+  assert_eq!(manager.windows_api.get_cursor_position(), target_monitor.center);
+}
+
+#[test]
+fn move_window_with_scrolling_source_reflows_without_stealing_focus_after_spatial_transfer() {
+  let (mut manager, target_monitor) = vertical_mixed_layout_manager(Direction::Down, Layout::Spatial);
+  let moved_handle = WindowHandle::new(1);
+  let source_workspace = manager.scrolling.get_workspace_containing(moved_handle).unwrap();
+  let source_monitor = manager.workspace_manager.monitor_for_workspace(source_workspace).unwrap();
+  let remaining_handle = WindowHandle::new(2);
+  MockWindowsApi::add_or_update_window(
+    remaining_handle,
+    "Remaining".to_string(),
+    Sizing::new(600, 100, 300, 700),
+    false,
+    false,
+    false,
+  );
+  MockWindowsApi::place_window(remaining_handle, source_monitor.handle);
+  manager.reconcile_layouts();
+  MockWindowsApi::set_foreground_window(moved_handle);
+  MockWindowsApi::set_cursor_position(source_monitor.center);
+
+  manager.move_window(Direction::Down);
+
+  let remaining_placement = manager.windows_api.get_window_placement(remaining_handle).unwrap();
+  assert_eq!(
+    Point::from_center_of_rect(&remaining_placement.normal_position),
+    source_monitor.center
+  );
+  assert_eq!(
+    manager.scrolling.get_workspace_containing(remaining_handle),
+    Some(source_workspace)
+  );
+  assert_eq!(manager.windows_api.get_foreground_window(), Some(moved_handle));
+  assert_eq!(manager.windows_api.get_cursor_position(), target_monitor.center);
+}
+
+#[test]
+fn move_window_when_scrolling_vertically_move_does_not_enter_another_scrolling_monitor() {
+  let (mut manager, _target_monitor) = vertical_mixed_layout_manager(Direction::Down, Layout::Scrolling);
+  let handle = WindowHandle::new(1);
+  let source_workspace = manager.scrolling.get_workspace_containing(handle).unwrap();
+  let before = manager.windows_api.get_window_placement(handle).unwrap();
+
+  manager.move_window(Direction::Down);
+
+  assert_eq!(manager.windows_api.get_window_placement(handle).unwrap(), before);
+  assert_eq!(manager.scrolling.get_workspace_containing(handle), Some(source_workspace));
+}
+
+#[test]
+fn move_window_with_spatial_monitor_crossing_is_adopted_by_scrolling_reconciliation() {
+  MockWindowsApi::reset();
+  let directory = create_temp_directory();
+  let workspace_manager = WorkspaceManager::new_test(true, directory.path().join("workspaces.toml"));
+  let configuration_provider = Arc::new(Mutex::new(ConfigurationProvider::default()));
+  configuration_provider
+    .lock()
+    .unwrap()
+    .set_monitor_layout("DISPLAY2", Layout::Scrolling);
+  let handle = WindowHandle::new(1);
+  MockWindowsApi::add_or_update_window(
+    handle,
+    "Primary".to_string(),
+    Sizing::left_half_of_screen(Rect::new(0, 0, 1920, 1030), 20),
+    false,
+    false,
+    true,
+  );
+  MockWindowsApi::place_window(handle, 1.into());
+  let mut manager = WindowManager {
+    configuration_provider,
+    placement: Default::default(),
+    allow_moving_cursor_after_close_or_minimise: true,
+    scrolling: Default::default(),
+    spatial: Default::default(),
+    workspace_manager,
+    virtual_desktop_manager: None,
+    windows_api: MockWindowsApi,
+  };
+
+  manager.move_window(Direction::Left);
+
+  assert!(manager.scrolling.get_workspace_containing(handle).is_none());
+
+  MockWindowsApi::assign_window_to_monitor(handle, 2.into());
+  manager.reconcile_layouts();
+
+  assert!(manager.scrolling.get_workspace_containing(handle).is_some());
+}
+
+#[test]
+fn move_window_with_scrolling_horizontal_move_does_not_enter_spatial_monitor() {
+  let (mut manager, _directory) = scrolling_manager();
+  manager
+    .configuration_provider
+    .lock()
+    .unwrap()
+    .set_monitor_layout("DISPLAY2", Layout::Spatial);
+  manager.reconcile_layouts();
+  let handle = WindowHandle::new(1);
+  let source_workspace = manager.scrolling.get_workspace_containing(handle).unwrap();
+  let before = manager.windows_api.get_window_placement(handle).unwrap();
+
+  manager.move_window(Direction::Left);
+
+  assert_eq!(manager.windows_api.get_window_placement(handle).unwrap(), before);
+  assert_eq!(manager.scrolling.get_workspace_containing(handle), Some(source_workspace));
 }
 
 #[test]
@@ -158,7 +356,7 @@ fn minimise_window_when_another_window_is_present() {
   assert_eq!(manager.windows_api.get_foreground_window(), Some(other_window_handle));
 }
 #[test]
-fn reconciliation_only_manages_scrolling_monitors() {
+fn reconcile_layouts_only_manages_scrolling_monitors() {
   MockWindowsApi::reset();
   let directory = create_temp_directory();
   let workspace_manager = WorkspaceManager::new_test(true, directory.path().join("workspaces.toml"));
@@ -196,7 +394,7 @@ fn reconciliation_only_manages_scrolling_monitors() {
 }
 
 #[test]
-fn changing_default_from_spatial_to_scrolling_adopts_active_windows() {
+fn reconcile_layouts_when_changing_default_from_spatial_to_scrolling_adopts_active_windows() {
   MockWindowsApi::reset();
   let directory = create_temp_directory();
   let workspace_manager = WorkspaceManager::new_test(true, directory.path().join("workspaces.toml"));
@@ -220,7 +418,7 @@ fn changing_default_from_spatial_to_scrolling_adopts_active_windows() {
 }
 
 #[test]
-fn changing_default_from_scrolling_to_spatial_restores_and_releases_active_windows() {
+fn reconcile_layouts_when_changing_default_from_scrolling_to_spatial_restores_and_releases_active_windows() {
   let (mut manager, _directory) = scrolling_manager();
   let second = WindowHandle::new(2);
   MockWindowsApi::add_or_update_window(
@@ -251,7 +449,7 @@ fn changing_default_from_scrolling_to_spatial_restores_and_releases_active_windo
 }
 
 #[test]
-fn changing_default_to_spatial_keeps_overridden_scrolling_monitor_managed() {
+fn reconcile_layouts_when_changing_default_to_spatial_keeps_overridden_scrolling_monitor_managed() {
   let (mut manager, _directory) = scrolling_manager();
   let secondary = WindowHandle::new(2);
   MockWindowsApi::add_or_update_window(
@@ -283,48 +481,7 @@ fn changing_default_to_spatial_keeps_overridden_scrolling_monitor_managed() {
 }
 
 #[test]
-fn spatial_monitor_crossing_is_adopted_by_scrolling_reconciliation() {
-  MockWindowsApi::reset();
-  let directory = create_temp_directory();
-  let workspace_manager = WorkspaceManager::new_test(true, directory.path().join("workspaces.toml"));
-  let configuration_provider = Arc::new(Mutex::new(ConfigurationProvider::default()));
-  configuration_provider
-    .lock()
-    .unwrap()
-    .set_monitor_layout("DISPLAY2", Layout::Scrolling);
-  let handle = WindowHandle::new(1);
-  MockWindowsApi::add_or_update_window(
-    handle,
-    "Primary".to_string(),
-    Sizing::left_half_of_screen(Rect::new(0, 0, 1920, 1030), 20),
-    false,
-    false,
-    true,
-  );
-  MockWindowsApi::place_window(handle, 1.into());
-  let mut manager = WindowManager {
-    configuration_provider,
-    placement: Default::default(),
-    allow_moving_cursor_after_close_or_minimise: true,
-    scrolling: Default::default(),
-    spatial: Default::default(),
-    workspace_manager,
-    virtual_desktop_manager: None,
-    windows_api: MockWindowsApi,
-  };
-
-  manager.move_window(Direction::Left);
-
-  assert!(manager.scrolling.get_workspace_containing(handle).is_none());
-
-  MockWindowsApi::assign_window_to_monitor(handle, 2.into());
-  manager.reconcile_layouts();
-
-  assert!(manager.scrolling.get_workspace_containing(handle).is_some());
-}
-
-#[test]
-fn moving_from_scrolling_to_spatial_removes_strip_membership() {
+fn move_window_to_workspace_when_moving_from_scrolling_to_spatial_removes_strip_membership() {
   let (mut manager, _directory) = scrolling_manager();
   manager
     .configuration_provider
@@ -346,7 +503,7 @@ fn moving_from_scrolling_to_spatial_removes_strip_membership() {
 }
 
 #[test]
-fn moving_from_spatial_to_scrolling_inserts_strip_membership() {
+fn move_window_to_workspace_when_moving_from_spatial_to_scrolling_inserts_strip_membership() {
   MockWindowsApi::reset();
   let directory = create_temp_directory();
   let workspace_manager = WorkspaceManager::new_test(false, directory.path().join("workspaces.toml"));

--- a/src/window_manager/window_manager.rs
+++ b/src/window_manager/window_manager.rs
@@ -153,7 +153,7 @@ impl<T: WindowsApi + Clone> WindowManager<T> {
           .scrolling
           .reorder(&self.windows_api, &self.workspace_manager, direction, margin);
       } else {
-        self.move_scrolling_window_to_spatial_monitor(direction);
+        self.move_scrolling_window_to_monitor(direction);
       }
       return;
     }
@@ -162,16 +162,16 @@ impl<T: WindowsApi + Clone> WindowManager<T> {
       .move_window(&self.windows_api, &self.placement, direction, self.margin());
   }
 
-  /// Moves the active window from a scrolling layout monitor to one that has a spatial layout. This method:
+  /// Transfers the active scrolling window vertically to an adjacent monitor. This method:
   /// - Gets the foreground window and its scrolling layout workspace
-  /// - Finds the adjacent monitor in the requested direction
-  /// - Confirms that monitor’s active workspace uses spatial layout
-  /// - Removes the window from its strip
+  /// - Finds the adjacent monitor, its active workspace, and its layout
+  /// - Removes the window from its source strip while retaining its [`WidthPreset`]
   /// - Updates the remaining source strip without changing focus
-  /// - Moves and near-maximises the window on the target monitor
-  /// - Centres the cursor and keeps the moved window foreground
+  /// - If target monitor has spatial layout: Near-maximises the window
+  /// - If target monitor has scrolling layout: Appends the window with its [`WidthPreset`] and updates the strip
+  /// - Centres the cursor and keeps the moved window foreground on either target
   /// - No-ops when any required window, workspace, monitor, or layout is unavailable
-  fn move_scrolling_window_to_spatial_monitor(&mut self, direction: Direction) {
+  fn move_scrolling_window_to_monitor(&mut self, direction: Direction) {
     let Some(handle) = self.windows_api.get_foreground_window() else {
       return;
     };
@@ -193,21 +193,41 @@ impl<T: WindowsApi + Clone> WindowManager<T> {
     else {
       return;
     };
-    if self.get_layout_for_workspace(target_workspace_id) != Some(Layout::Spatial) {
+    let Some(target_layout) = self.get_layout_for_workspace(target_workspace_id) else {
       return;
-    }
-    if self.scrolling.remove(source_workspace_id, handle).is_none() {
+    };
+    let Some(transferred_preset) = self.scrolling.remove(source_workspace_id, handle) else {
       return;
-    }
+    };
 
     let margin = self.margin();
     self
       .scrolling
       .reflow(&self.windows_api, &self.workspace_manager, source_workspace_id, margin);
-    self
-      .spatial
-      .move_window_to_monitor(&self.windows_api, &self.placement, handle, &target_monitor, margin);
-    self.windows_api.set_foreground_window(handle);
+    match target_layout {
+      Layout::Spatial => {
+        self
+          .spatial
+          .move_window_to_monitor(&self.windows_api, &self.placement, handle, &target_monitor, margin);
+        self.windows_api.set_foreground_window(handle);
+      }
+      Layout::Scrolling => {
+        self.scrolling.insert(
+          &self.windows_api,
+          &self.workspace_manager,
+          target_workspace_id,
+          handle,
+          Some(transferred_preset),
+          margin,
+        );
+        self
+          .scrolling
+          .reflow(&self.windows_api, &self.workspace_manager, target_workspace_id, margin);
+        self
+          .scrolling
+          .focus(&self.windows_api, &self.workspace_manager, target_workspace_id, margin);
+      }
+    }
   }
 
   /// Resizes a window on a monitor using the spatial layout. Scrolling windows remain unchanged.

--- a/src/window_manager/window_manager.rs
+++ b/src/window_manager/window_manager.rs
@@ -152,12 +152,62 @@ impl<T: WindowsApi + Clone> WindowManager<T> {
         self
           .scrolling
           .reorder(&self.windows_api, &self.workspace_manager, direction, margin);
+      } else {
+        self.move_scrolling_window_to_spatial_monitor(direction);
       }
       return;
     }
     self
       .spatial
       .move_window(&self.windows_api, &self.placement, direction, self.margin());
+  }
+
+  /// Moves the active window from a scrolling layout monitor to one that has a spatial layout. This method:
+  /// - Gets the foreground window and its scrolling layout workspace
+  /// - Finds the adjacent monitor in the requested direction
+  /// - Confirms that monitor’s active workspace uses spatial layout
+  /// - Removes the window from its strip
+  /// - Updates the remaining source strip without changing focus
+  /// - Moves and near-maximises the window on the target monitor
+  /// - Centres the cursor and keeps the moved window foreground
+  /// - No-ops when any required window, workspace, monitor, or layout is unavailable
+  fn move_scrolling_window_to_spatial_monitor(&mut self, direction: Direction) {
+    let Some(handle) = self.windows_api.get_foreground_window() else {
+      return;
+    };
+    let Some(source_workspace_id) = self.scrolling.get_workspace_containing(handle) else {
+      return;
+    };
+    let Some(source_monitor) = self.workspace_manager.monitor_for_workspace(source_workspace_id) else {
+      return;
+    };
+    let monitors = self.windows_api.get_all_monitors();
+    let Some(target_monitor) = monitors.get(direction, source_monitor.handle).cloned() else {
+      return;
+    };
+    let Some(target_workspace_id) = self
+      .workspace_manager
+      .active_workspace_ids()
+      .into_iter()
+      .find(|workspace| workspace.monitor_id == target_monitor.id)
+    else {
+      return;
+    };
+    if self.get_layout_for_workspace(target_workspace_id) != Some(Layout::Spatial) {
+      return;
+    }
+    if self.scrolling.remove(source_workspace_id, handle).is_none() {
+      return;
+    }
+
+    let margin = self.margin();
+    self
+      .scrolling
+      .reflow(&self.windows_api, &self.workspace_manager, source_workspace_id, margin);
+    self
+      .spatial
+      .move_window_to_monitor(&self.windows_api, &self.placement, handle, &target_monitor, margin);
+    self.windows_api.set_foreground_window(handle);
   }
 
   /// Resizes a window on a monitor using the spatial layout. Scrolling windows remain unchanged.


### PR DESCRIPTION
## Bugs

- Fix bug for some windows where resizing a window on the spatial layout could move the window to the right or give it an invalid size (between 25% and 50%) towards the left (some windows - at least Firefox - still have this problem, so this is a partial fix)

## Features

- Allow moving windows vertically between any layout type; horizontally moving out of the scrolling layout only works via the `MoveWindowToWorkspace` command/hotkey

## Other

- Update README accordingly