### PR TITLE
Add Scoop support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           echo "new_version=$new_version" >> $env:GITHUB_OUTPUT
 
       - name: Build release
-        run: cargo build --release --locked
+        run: cargo build --release
 
       - name: Decode certificate
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,19 +37,23 @@ jobs:
           echo "new_version=$new_version" >> $env:GITHUB_OUTPUT
 
       - name: Build release
-        run: cargo build --release
+        run: cargo build --release --locked
 
       - name: Decode certificate
+        env:
+          SIGNING_CERT_BASE64: ${{ secrets.SIGNING_CERT_BASE64 }}
         run: |
-          $certBytes = [Convert]::FromBase64String("${{ secrets.SIGNING_CERT_BASE64 }}")
+          $certBytes = [Convert]::FromBase64String($env:SIGNING_CERT_BASE64)
           $certPath = ".\cert.pfx"
           [IO.File]::WriteAllBytes($certPath, $certBytes)
           echo "CERT_PATH=$certPath" >> $env:GITHUB_ENV
 
       - name: Sign binary
+        env:
+          SIGNING_CERT_PASSWORD: ${{ secrets.SIGNING_CERT_PASSWORD }}
         run: |
           $signtoolPath = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\signtool.exe" | Select-Object -First 1 -ExpandProperty FullName
-          & $signtoolPath sign /f $env:CERT_PATH /p "${{ secrets.SIGNING_CERT_PASSWORD }}" /tr "http://timestamp.digicert.com" /td SHA256 /fd SHA256 $env:RELEASE_EXECUTABLE
+          & $signtoolPath sign /f $env:CERT_PATH /p $env:SIGNING_CERT_PASSWORD /tr "http://timestamp.digicert.com" /td SHA256 /fd SHA256 $env:RELEASE_EXECUTABLE
           if ($LASTEXITCODE -ne 0) {
             Write-Host "Signing failed with exit code $LASTEXITCODE"
             exit 1
@@ -86,15 +90,12 @@ jobs:
           $assetName = "randolf-v$version.exe"
           $hash = (Get-FileHash $env:RELEASE_EXECUTABLE -Algorithm SHA256).Hash.ToLowerInvariant()
           $manifest = Get-Content randolf.json -Raw | ConvertFrom-Json
-
           $manifest.version = $version
           $manifest.url = "https://github.com/${{ github.repository }}/releases/download/v$version/$assetName#/$executableName"
           $manifest.hash = "sha256:$hash"
           $manifest.bin = $executableName
           $manifest.autoupdate.url = "https://github.com/${{ github.repository }}/releases/download/v`$version/randolf-v`$version.exe#/$executableName"
-
           $manifest | ConvertTo-Json -Depth 10 | Set-Content randolf.json -Encoding utf8
-
           git add randolf.json
           git commit -m "Update Scoop manifest to $version"
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,19 +5,19 @@ on:
 jobs:
   build-and-release:
     runs-on: windows-latest
+    permissions:
+      contents: write
+    env:
+      RELEASE_EXECUTABLE: ./target/release/randolf.exe
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Bump version
         id: bump-version
@@ -49,13 +49,13 @@ jobs:
       - name: Sign binary
         run: |
           $signtoolPath = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\signtool.exe" | Select-Object -First 1 -ExpandProperty FullName
-          & $signtoolPath sign /f $env:CERT_PATH /p "${{ secrets.SIGNING_CERT_PASSWORD }}" /tr "http://timestamp.digicert.com" /td SHA256 /fd SHA256 ./target/release/randolf.exe
+          & $signtoolPath sign /f $env:CERT_PATH /p "${{ secrets.SIGNING_CERT_PASSWORD }}" /tr "http://timestamp.digicert.com" /td SHA256 /fd SHA256 $env:RELEASE_EXECUTABLE
           if ($LASTEXITCODE -ne 0) {
             Write-Host "Signing failed with exit code $LASTEXITCODE"
             exit 1
           }
           Write-Host "Checking signature..."
-          $signature = Get-AuthenticodeSignature ./target/release/randolf.exe
+          $signature = Get-AuthenticodeSignature $env:RELEASE_EXECUTABLE
           if ($signature.Status -eq "Valid") {
             Write-Host "Binary successfully signed."
           } elseif ($signature.Status -eq "UnknownError") {
@@ -67,22 +67,34 @@ jobs:
           }
 
       - name: Create GitHub release
-        id: create_release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ steps.bump-version.outputs.new_version }}
-          release_name: Release v${{ steps.bump-version.outputs.new_version }}
-          draft: false
-          prerelease: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $version = "${{ steps.bump-version.outputs.new_version }}"
+          $assetPath = Join-Path $env:RUNNER_TEMP "randolf-v$version.exe"
+          $targetCommit = git rev-parse HEAD
+          Copy-Item $env:RELEASE_EXECUTABLE $assetPath
+          gh release create "v$version" $assetPath --target $targetCommit --title "Release v$version" --notes ""
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
 
-      - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./target/release/randolf.exe
-          asset_name: randolf-v${{ steps.bump-version.outputs.new_version }}.exe
-          asset_content_type: application/octet-stream
+      - name: Update Scoop manifest
+        run: |
+          $version = "${{ steps.bump-version.outputs.new_version }}"
+          $executableName = Split-Path $env:RELEASE_EXECUTABLE -Leaf
+          $assetName = "randolf-v$version.exe"
+          $hash = (Get-FileHash $env:RELEASE_EXECUTABLE -Algorithm SHA256).Hash.ToLowerInvariant()
+          $manifest = Get-Content randolf.json -Raw | ConvertFrom-Json
+
+          $manifest.version = $version
+          $manifest.url = "https://github.com/${{ github.repository }}/releases/download/v$version/$assetName#/$executableName"
+          $manifest.hash = "sha256:$hash"
+          $manifest.bin = $executableName
+          $manifest.autoupdate.url = "https://github.com/${{ github.repository }}/releases/download/v`$version/randolf-v`$version.exe#/$executableName"
+
+          $manifest | ConvertTo-Json -Depth 10 | Set-Content randolf.json -Encoding utf8
+
+          git add randolf.json
+          git commit -m "Update Scoop manifest to $version"
+          git push

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "randolf"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "crossbeam-channel",
  "directories",

--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ Resizing (and opening and moving) windows using hotkeys only:
 Using the scrolling layout with hotkeys only:
 ![Demo GIF 6](assets/demo_6.gif)
 
+## How to install
+
+The latest executable can be downloaded directly from https://github.com/kimgoetzke/randolf/releases/latest.
+
+Alternatively, you can install it using the Scoop package manager:
+
+```powershell
+scoop bucket add randolf https://github.com/kimgoetzke/randolf
+scoop install randolf/randolf
+```
+
 ## How to configure
 
 > [!NOTE]

--- a/randolf.json
+++ b/randolf.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.31.0",
+  "description": "A small window management utility for Windows 11",
+  "homepage": "https://github.com/kimgoetzke/randolf",
+  "license": "MIT",
+  "url": "https://github.com/kimgoetzke/randolf/releases/download/v0.31.0/randolf-v0.31.0.exe#/randolf.exe",
+  "hash": "sha256:39deacb176a07803736a74208db483c6e89c682dbce0c635108bb5ba4992e79c",
+  "bin": "randolf.exe",
+  "checkver": {
+    "github": "https://github.com/kimgoetzke/randolf"
+  },
+  "autoupdate": {
+    "url": "https://github.com/kimgoetzke/randolf/releases/download/v$version/randolf-v$version.exe#/randolf.exe"
+  }
+}


### PR DESCRIPTION
## Features

- Allow downloading Randolf using Scoop, the package manager


## Other 

- Update GitHub release action to stop using old/unmaintained actions
- Add step to GitHub release action to keep Scoop manifest up-to-date