### PR TITLE
Fix broken release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,6 @@ jobs:
     permissions: {}
     env:
       RELEASE_EXECUTABLE: ./unsigned/randolf.exe
-      CERT_PATH: ${{ runner.temp }}\cert.pfx
 
     steps:
       - name: Retrieve unsigned executable
@@ -91,14 +90,16 @@ jobs:
           SIGNING_CERT_BASE64: ${{ secrets.SIGNING_CERT_BASE64 }}
         run: |
           $certBytes = [Convert]::FromBase64String($env:SIGNING_CERT_BASE64)
-          [IO.File]::WriteAllBytes($env:CERT_PATH, $certBytes)
+          $certPath = Join-Path $env:RUNNER_TEMP "cert.pfx"
+          [IO.File]::WriteAllBytes($certPath, $certBytes)
 
       - name: Sign binary
         env:
           SIGNING_CERT_PASSWORD: ${{ secrets.SIGNING_CERT_PASSWORD }}
         run: |
+          $certPath = Join-Path $env:RUNNER_TEMP "cert.pfx"
           $signtoolPath = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\signtool.exe" | Select-Object -First 1 -ExpandProperty FullName
-          & $signtoolPath sign /f $env:CERT_PATH /p $env:SIGNING_CERT_PASSWORD /tr "http://timestamp.digicert.com" /td SHA256 /fd SHA256 $env:RELEASE_EXECUTABLE
+          & $signtoolPath sign /f $certPath /p $env:SIGNING_CERT_PASSWORD /tr "http://timestamp.digicert.com" /td SHA256 /fd SHA256 $env:RELEASE_EXECUTABLE
           if ($LASTEXITCODE -ne 0) {
             Write-Host "Signing failed with exit code $LASTEXITCODE"
             exit 1
@@ -117,7 +118,7 @@ jobs:
 
       - name: Remove certificate
         if: always()
-        run: Remove-Item -LiteralPath $env:CERT_PATH -Force -ErrorAction SilentlyContinue
+        run: Remove-Item -LiteralPath (Join-Path $env:RUNNER_TEMP "cert.pfx") -Force -ErrorAction SilentlyContinue
 
       - name: Store signed executable
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Other

- Undo use of ` ${{ runner.temp }} ` while GitHub evaluates job-level env